### PR TITLE
Support Tokyo region pricing

### DIFF
--- a/lib/awscosts/ec2.rb
+++ b/lib/awscosts/ec2.rb
@@ -20,7 +20,7 @@ class AWSCosts::EC2
     'eu-central-1' => "eu-central-1",
     'ap-southeast-1' => "apac-sin",
     'ap-southeast-2' =>"apac-syd",
-    'ap-northeast-1' =>"apac-tokyo",
+    'ap-northeast-1' =>"ap-northeast-1",
     'sa-east-1' => "sa-east-1"
   }
 


### PR DESCRIPTION
I found I can't fetch ap-northeast-1 region's EBS pricing info.
I couldn't understand what `REGION_MAPPING` is for (should equal to region name) but I fixed this region's value for now.